### PR TITLE
url.parse should not set both path and pathname.

### DIFF
--- a/modules/framework.lua
+++ b/modules/framework.lua
@@ -117,7 +117,6 @@ function framework.util.parseUrl(url, parseQueryString)
     host = host,
     hostname = hostname,
     port = port,
-    path = path or '/',
     pathname = pathname or '/',
     search = search,
     query = query,


### PR DESCRIPTION
Signed-off-by: GabrielNicolasAvellaneda avellaneda.gabriel@gmail.com
