### PR TITLE
README Updates ; Handling of Socket Errors on Measurement Reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,21 @@
+TrueSight Pulse HTTP(S) Check Plugin
+------------------------------------
+
 Polls a set of URLs and reports on the response time.The plugin allows multiple URLs to be polled and each of those URLs to set their own Poll interval. The URLs can require authentication, the plugin supports basic HTTP authentication.
+
+
+
+## Redirect Behaviour
+
+The following table provides the behaviour of measurement values 
+
+|Method|Ignore Status Code |Allow Direct|Max Redirect|Behavior|Usage|
+|:----------:|:----------:|:------:|:----:|:---:|
+| DELETE,GET,POST,PUT|False| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s) if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validate that redirects are working correctly|
+| DELETE,GET,POST,PUT|False| False | Any| Returns response time measurement if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validating that endpoint returns a success ful HTTP(s) status code 2XX|
+|DELETE,GET,POST,PUT|True| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s)|Validates the endpoint redirects up to _Max Redirect_|
+|DELETE,GET,POST,PUT|True| False | Any|Returns response time regardless of the return HTTP code status|Measurement of the response time of the endpoint for any HTTP status code|
+
 
 ### Prerequisites
 
@@ -6,7 +23,7 @@ Polls a set of URLs and reports on the response time.The plugin allows multiple 
 |:----------|:-----:|:-------:|:-------:|:----:|
 | Supported |   v   |    v    |    v    |  v   |
 
-#### Boundary Meter versions v4.2 or later
+### Boundary Meter versions v4.2 or later
 
 - To install new meter go to Settings->Installation or [see instructions](https://help.boundary.com/hc/en-us/sections/200634331-Installation).
 - To upgrade the meter to the latest version - [see instructions](https://help.boundary.com/hc/en-us/articles/201573102-Upgrading-the-Boundary-Meter).
@@ -29,8 +46,7 @@ None
 |Username           |(optional) The username required to access the endpoint                                                               |
 |Password           |(optional) The password required to access the endpoint                                                               |
 |POST data          |(optional) Additional information to pass along to the endpoint. Key Values pairs, "key=value" one per line           |
-| Follow Redirects | Follow redirection of 3xx responses. |
-| Max Redirects | Max numbers of redirections to follow. |
+
 ### Metrics Collected
 
 |Metric Name       |Description               |

--- a/README.md
+++ b/README.md
@@ -5,33 +5,23 @@ Polls a set of URLs and reports on the response time.The plugin allows multiple 
 
 
 
-## Measurement Behavior
+### Measurement Behavior
 
-The following table provides the behaviour of measurement values for all HTTP response codes
+The HTTP check plugin permits specification of an expected response code from an end point. The table below summarizes the measurement behavior depending on the expected response code.
 
-|HTTP Response|Method|Ignore Status Code |Allow Direct|Max Redirect|Behavior|Usage|
-|:----------:|:----------:|:------:|:----:|:---:|
-|2XX| DELETE,GET,POST,PUT|Any| Any | Any| Returns response time from request.|Measurement of 2XX response|
-|3XX| DELETE,GET,POST,PUT|False| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s) if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validate that redirects are working correctly|
-|3XX| DELETE,GET,POST,PUT|False| False | Any| Returns a measurement of -1 and an error event is raised|Checks and endpoint for 3XX response code|
-|3XX|DELETE,GET,POST,PUT|True| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s)|Validates the endpoint redirects up to _Max Redirect_|
-|3XX|DELETE,GET,POST,PUT|True| False | Any|Returns response time regardless of the return HTTP code status|Measurement of the response time of the endpoint for any HTTP status code|
-|4XX|DELETE,GET,POST,PUT|True| Any | Any|Returns response time from request. |Measurement of 4XX response |
-|4XX|DELETE,GET,POST,PUT|False| Any | Any|Returns a measurement of -1 and an error event is raised|Checks and endpoint for 4XX response code|
-|5XX|DELETE,GET,POST,PUT|True| Any | Any|Returns response time from request. |Measurement of 5XX response |
-|5XX|DELETE,GET,POST,PUT|False| Any | Any|Returns a measurement of -1 and an error event is raised|Checks and endpoint for 5XX response code|
+The HTTP plugin has an option to generate an error event if the return HTTP response does not meet the expected value.
 
-# Example
-|Method|Expected Response |Allow Direct|Max Redirect|Measurement|Usage|
-|:----------:|:------:|:----:|:---:|
-| DELETE,GET,POST,PUT|2XX| False | Any| Returns response time from request if response is 2XX otherwise returns a measurement value of -1 .|Measurement of 2XX response|
-| DELETE,GET,POST,PUT|2XX|True | Any| Redirects up to _Max Redirect_. if response is other than 2XX returns a measurement value of -1 and raises an error event.|Measurement of 2XX response|
-| DELETE,GET,POST,PUT|3XX|True|Any| Redirects up to _Max Redirect_. if response is other than 3XX returns a measurement value of -1 and raises an error event.|Checks that there are at least _Max Redirect_ redirects|
-| DELETE,GET,POST,PUT|3XX| False | Any| Returns response time from request if response is 3XX otherwise returns a measurement value of -1 .|Measures 3XX response time|
-|DELETE,GET,POST,PUT|4XX| False | Any|Returns response time from request if response is 4XX otherwise returns a measurement value of -1 .|Measurement of 4XX response |
-|DELETE,GET,POST,PUT|4XX| True | Any|Redirects up to _Max Redirect_. if response is other than 4XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 4XX response code |
-|DELETE,GET,POST,PUT|5XX| Any | Any|Returns response time from request if response is 5XX otherwise returns a measurement value of -1 .|Measurement of 5XX response |
-|DELETE,GET,POST,PUT|5XX| Any | Any|Redirects up to Max Redirect. if response is other than 5XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 5XX response code|
+|Expected Response |Allow Direct|Max Redirect|Measurement|Usage|
+|:----------------:|:----------:|:----------:|:---------|:---|
+|2XX|False|Any|Returns response time from request if response is 2XX otherwise returns a measurement value of -1 .|Measurement of 2XX response|
+|2XX|True | Any| Redirects up to _Max Redirect_. if response is other than 2XX returns a measurement value of -1 and raises an error event.|Measurement of 2XX response|
+|3XX|True|Any| Redirects up to _Max Redirect_. if response is other than 3XX returns a measurement value of -1 and raises an error event.|Checks that there are at least _Max Redirect_ redirects|
+|3XX| False | Any| Returns response time from request if response is 3XX otherwise returns a measurement value of -1 .|Measures 3XX response time|
+|4XX| False | Any|Returns response time from request if response is 4XX otherwise returns a measurement value of -1 .|Measurement of 4XX response |
+|4XX| True | Any|Redirects up to _Max Redirect_. if response is other than 4XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 4XX response code |
+|5XX| Any | Any|Returns response time from request if response is 5XX otherwise returns a measurement value of -1 .|Measurement of 5XX response |
+|5XX| Any | Any|Redirects up to Max Redirect. if response is other than 5XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 5XX response code|
+
 ### Prerequisites
 
 |     OS    | Linux | Windows | SmartOS | OS X |
@@ -52,12 +42,12 @@ None
 |Field Name         |Description                                                                                                           |
 |:------------------|:---------------------------------------------------------------------------------------------------------------------|
 |Source             |The source to display in the legend for the endpoint. Ex. www.google.com                                              |
-|Poll Time (sec)    |The Poll Interval to call your endpoint in seconds. Ex. 5                                                             |
-|Method             |The Method of the endpoint                                                                                            |
-|Protocol           |The protocol of the endpoint                                                                                          |
-|URL                |The URL of the endpoint. For example, www.yahoo.com or www.yahoo.com:8080/some-random-page                            |
-|Ignore Status Code |If any response from the server is considered valid, even an error, enable this.                                      |
-|Debug Level | If you are having issues with the plugin, you can enable additional debugging output to be shown in the Meter console |
+|Poll Time (sec)    |The Poll Interval to call your endpoint in seconds. Default is 5 seconds.                                                             |
+|Method             |The Method of the endpoint. One of the following: _DELETE_, _GET_, _POST_, or _PUT_.                                                                                           |
+|Protocol           |The protocol of the endpoint. Either _http_ or _https_.                                                                                           |
+|URL                |The host and path name. For example, www.yahoo.com or www.yahoo.com:8080/some-random-page                            |
+|Expected Response|Expected response from the endpoint one of the following values: 2XX, 3XX, 4XX, or 5XX                                     |
+|Debug Level | If you are having issues with the plugin, you can enable additional debugging output to be shown in the Meter console.|
 |Username           |(optional) The username required to access the endpoint                                                               |
 |Password           |(optional) The password required to access the endpoint                                                               |
 |POST data          |(optional) Additional information to pass along to the endpoint. Key Values pairs, "key=value" one per line           |

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ The HTTP plugin has an option to generate an error event if the return HTTP resp
 |Expected Response |Allow Direct|Max Redirect|Measurement|Usage|
 |:----------------:|:----------:|:----------:|:---------|:---|
 |2XX|False|Any|Returns response time from request if response is 2XX otherwise returns a measurement value of -1 .|Measurement of 2XX response|
-|2XX|True | Any| Redirects up to _Max Redirect_. if response is other than 2XX returns a measurement value of -1 and raises an error event.|Measurement of 2XX response|
-|3XX|True|Any| Redirects up to _Max Redirect_. if response is other than 3XX returns a measurement value of -1 and raises an error event.|Checks that there are at least _Max Redirect_ redirects|
+|2XX|True | Any| Redirects up to _Max Redirect_. if response is other than 2XX returns a measurement value of -1 and optionally raises an error event.|Measurement of 2XX response|
 |3XX| False | Any| Returns response time from request if response is 3XX otherwise returns a measurement value of -1 .|Measures 3XX response time|
+|3XX|True|Any| Redirects up to _Max Redirect_. if response is other than 3XX returns a measurement value of -1 and raises an error event.|Checks that there are at least _Max Redirect_ redirects|
 |4XX| False | Any|Returns response time from request if response is 4XX otherwise returns a measurement value of -1 .|Measurement of 4XX response |
 |4XX| True | Any|Redirects up to _Max Redirect_. if response is other than 4XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 4XX response code |
-|5XX| Any | Any|Returns response time from request if response is 5XX otherwise returns a measurement value of -1 .|Measurement of 5XX response |
-|5XX| Any | Any|Redirects up to Max Redirect. if response is other than 5XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 5XX response code|
+|5XX| False | Any|Returns response time from request if response is 5XX otherwise returns a measurement value of -1 .|Measurement of 5XX response |
+|5XX| True | Any|Redirects up to Max Redirect. if response is other than 5XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 5XX response code|
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,33 @@ Polls a set of URLs and reports on the response time.The plugin allows multiple 
 
 
 
-## Redirect Behaviour
+## Measurement Behavior
 
-The following table provides the behaviour of measurement values 
+The following table provides the behaviour of measurement values for all HTTP response codes
 
-|Method|Ignore Status Code |Allow Direct|Max Redirect|Behavior|Usage|
+|HTTP Response|Method|Ignore Status Code |Allow Direct|Max Redirect|Behavior|Usage|
 |:----------:|:----------:|:------:|:----:|:---:|
-| DELETE,GET,POST,PUT|False| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s) if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validate that redirects are working correctly|
-| DELETE,GET,POST,PUT|False| False | Any| Returns response time measurement if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validating that endpoint returns a success ful HTTP(s) status code 2XX|
-|DELETE,GET,POST,PUT|True| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s)|Validates the endpoint redirects up to _Max Redirect_|
-|DELETE,GET,POST,PUT|True| False | Any|Returns response time regardless of the return HTTP code status|Measurement of the response time of the endpoint for any HTTP status code|
+|2XX| DELETE,GET,POST,PUT|Any| Any | Any| Returns response time from request.|Measurement of 2XX response|
+|3XX| DELETE,GET,POST,PUT|False| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s) if HTTP response code is 2XX, otherwise measurement is -1 and an error event is raised|Validate that redirects are working correctly|
+|3XX| DELETE,GET,POST,PUT|False| False | Any| Returns a measurement of -1 and an error event is raised|Checks and endpoint for 3XX response code|
+|3XX|DELETE,GET,POST,PUT|True| True | Any| Performs up to _Max Redirect_ redirects and returns response time from initial request to 3XX redirect(s)|Validates the endpoint redirects up to _Max Redirect_|
+|3XX|DELETE,GET,POST,PUT|True| False | Any|Returns response time regardless of the return HTTP code status|Measurement of the response time of the endpoint for any HTTP status code|
+|4XX|DELETE,GET,POST,PUT|True| Any | Any|Returns response time from request. |Measurement of 4XX response |
+|4XX|DELETE,GET,POST,PUT|False| Any | Any|Returns a measurement of -1 and an error event is raised|Checks and endpoint for 4XX response code|
+|5XX|DELETE,GET,POST,PUT|True| Any | Any|Returns response time from request. |Measurement of 5XX response |
+|5XX|DELETE,GET,POST,PUT|False| Any | Any|Returns a measurement of -1 and an error event is raised|Checks and endpoint for 5XX response code|
 
-
+# Example
+|Method|Expected Response |Allow Direct|Max Redirect|Measurement|Usage|
+|:----------:|:------:|:----:|:---:|
+| DELETE,GET,POST,PUT|2XX| False | Any| Returns response time from request if response is 2XX otherwise returns a measurement value of -1 .|Measurement of 2XX response|
+| DELETE,GET,POST,PUT|2XX|True | Any| Redirects up to _Max Redirect_. if response is other than 2XX returns a measurement value of -1 and raises an error event.|Measurement of 2XX response|
+| DELETE,GET,POST,PUT|3XX|True|Any| Redirects up to _Max Redirect_. if response is other than 3XX returns a measurement value of -1 and raises an error event.|Checks that there are at least _Max Redirect_ redirects|
+| DELETE,GET,POST,PUT|3XX| False | Any| Returns response time from request if response is 3XX otherwise returns a measurement value of -1 .|Measures 3XX response time|
+|DELETE,GET,POST,PUT|4XX| False | Any|Returns response time from request if response is 4XX otherwise returns a measurement value of -1 .|Measurement of 4XX response |
+|DELETE,GET,POST,PUT|4XX| True | Any|Redirects up to _Max Redirect_. if response is other than 4XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 4XX response code |
+|DELETE,GET,POST,PUT|5XX| Any | Any|Returns response time from request if response is 5XX otherwise returns a measurement value of -1 .|Measurement of 5XX response |
+|DELETE,GET,POST,PUT|5XX| Any | Any|Redirects up to Max Redirect. if response is other than 5XX returns a measurement value of -1 and raises an error event.|Checks and endpoint for 5XX response code|
 ### Prerequisites
 
 |     OS    | Linux | Windows | SmartOS | OS X |

--- a/init.lua
+++ b/init.lua
@@ -68,6 +68,10 @@ function plugin:onError(err)
     err.source = err.context.info.source
     err.message = err.message and err.message .. ' for ' .. err.context.options.href   
   end
+  result = {}
+  result['HTTP_RESPONSETIME'] = {value = -1, source = err.context.info.source}
+  self:report(result)
+
   return err
 end
 

--- a/param.socket.json
+++ b/param.socket.json
@@ -1,0 +1,50 @@
+{
+  "items": [
+    {
+      "source": "host_not_found",
+      "pollInterval": 1,
+      "method": "GET",
+      "protocol": "http",
+      "url": "mywebsite.down.the.road.com:8000/hello",
+      "ignoreStatusCode": false,
+      "debug_level": "notset",
+      "follow_redirects": true,
+      "max_redirects" : 0,
+      "username": "",
+      "password": "",
+      "postdata": [
+      ]
+    },
+    {
+      "source": "no_response",
+      "pollInterval": 1,
+      "method": "GET",
+      "protocol": "http",
+      "url": "localhost:8001/hello",
+      "ignoreStatusCode": false,
+      "debug_level": "notset",
+      "follow_redirects": true,
+      "max_redirects" : 0,
+      "username": "",
+      "password": "",
+      "postdata": [
+      ]
+    },
+    {
+      "source": "connection_refused",
+      "pollInterval": 1,
+      "method": "GET",
+      "protocol": "http",
+      "url": "localhost:10000/hello",
+      "ignoreStatusCode": false,
+      "debug_level": "notset",
+      "follow_redirects": true,
+      "max_redirects" : 0,
+      "username": "",
+      "password": "",
+      "postdata": [
+      ]
+    }
+  ],
+  "pollInterval": 1000
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
   "name" : "Boundary Http Check Plugin",
-  "version" : "0.9.4",
+  "version" : "0.9.5",
   "meterVersionRequired" : "4.2.0-611",
   "unsupportedPlatforms" : [ ],
   "tags" : "http",


### PR DESCRIPTION
1.  Changes to README. Changes need to be verified
2.  Socket errors to do not correct report measurement for the http time of -1 under the following conditions, although events a reproduced:
- Connection Refused
- Time out
- Unable resolve host.
1. Add additional param.json file testing particular socket failure conditions.
